### PR TITLE
Optimizations

### DIFF
--- a/src/OpenStack/ObjectStore/v1/Resource/RemoteObject.php
+++ b/src/OpenStack/ObjectStore/v1/Resource/RemoteObject.php
@@ -444,7 +444,9 @@ class RemoteObject extends Object
     protected function localFileStream()
     {
         $tmp = fopen('php://temp', 'rw');
-        fwrite($tmp, $this->content(), $this->contentLength());
+        while (!$this->content->eof()) {
+            fwrite($tmp, $this->content->read(8096));
+        }
         rewind($tmp);
 
         return $tmp;

--- a/src/OpenStack/ObjectStore/v1/Resource/StreamWrapper.php
+++ b/src/OpenStack/ObjectStore/v1/Resource/StreamWrapper.php
@@ -832,7 +832,7 @@ class StreamWrapper
 
                 $this->objStream = $tmpStream;
             } else {
-                $this->objStream = $this->obj->stream();
+                $this->objStream = $stream;
             }
 
             // Append mode requires seeking to the end.


### PR DESCRIPTION
I had problems with a 3GB file transfer in stream (PHP memory limit error) : all the file contents are loaded in memory.
Here are my corrections (and it works in my environment).
